### PR TITLE
feat: mark done if GH action run was canceled

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16.x
-          cache: pnpm
 
       - run: npx changelogithub
         env:

--- a/index.js
+++ b/index.js
@@ -124,35 +124,47 @@
       })
   }
 
+  function getReasonMarkedDone(item) {
+    if (item.isClosed && (item.read || item.type === 'subscribed'))
+      return 'Closed / merged'
+
+    if (item.title.startsWith('chore(deps): update ') && (item.read || item.type === 'subscribed'))
+      return 'Renovate bot'
+
+    if (item.url.match('/pull/[0-9]+/files/'))
+      return 'New commit pushed to PR'
+  }
+
   function autoMarkDone() {
     const items = getIssues()
 
     console.log(items)
     let count = 0
 
+    const done = []
+
     items.forEach((i) => {
       // skip bookmarked notifications
       if (i.starred)
         return
 
-      // mark done for closed/merged notifications, either read or not been mentioned
-      if (i.isClosed && (i.read || i.type === 'subscribed')) {
-        count += 1
-        i.markDone()
-      }
+      const reason = getReasonMarkedDone(i)
+      if (!reason)
+        return
 
-      // Renovate bot
-      else if (i.title.startsWith('chore(deps): update ') && (i.read || i.type === 'subscribed')) {
-        count += 1
-        i.markDone()
-      }
-
-      // New commit pushed to PR
-      else if (i.url.match('/pull/[0-9]+/files/')) {
-        count += 1
-        i.markDone()
-      }
+      count++
+      i.markDone()
+      done.push({
+        title: i.title,
+        reason,
+        link: i.link,
+      })
     })
+
+    if (done.length) {
+      console.log(`[${NAME}]`, `${count} notifications marked done`)
+      console.table(done)
+    }
 
     // Refresh page after marking done (expand the pagination)
     if (count >= 5)

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Refined GitHub Notifications
 // @namespace    https://greasyfork.org/en/scripts/461320-refined-github-notifications
-// @version      0.1.1
+// @version      0.1.2
 // @description  Enhances the GitHub Notifications page, making it more productive and less noisy.
 // @author       Anthony Fu (https://github.com/antfu)
 // @license      MIT

--- a/index.js
+++ b/index.js
@@ -133,6 +133,9 @@
 
     if (item.url.match('/pull/[0-9]+/files/'))
       return 'New commit pushed to PR'
+
+    if (item.type === 'ci activity' && /workflow run cancell?ed/.test(item.title))
+        return 'GH PR Audit Action workflow run cancelled, probably due to another run taking precedence'
   }
 
   function autoMarkDone() {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "refined-github-notifications",
   "type": "module",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "packageManager": "pnpm@7.12.0",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",


### PR DESCRIPTION
depends on https://github.com/antfu/refined-github-notifications/pull/2

## Test Plan

notifications with this title prefix should get canceled:

```
GH PR Audit Action workflow run cancelled for ...
```